### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
   "devDependencies": {
-    "commonform-commonmark": "^5.2.0",
+    "commonform-commonmark": "^6.0.0",
     "commonform-critique": "^1.0.3",
-    "commonform-docx": "^5.0.3",
-    "commonform-html": "^3.2.0",
+    "commonform-docx": "^5.3.0",
+    "commonform-html": "^3.6.1",
     "commonform-lint": "^3.0.2",
-    "json": "^9.0.6"
+    "json": "^10.0.0"
   }
 }


### PR DESCRIPTION
Update dependencies to latest versions. 

When using Common Forms Components with commonform-commonmark v5.2.0, `make lint` throws `Invalid content after component URL` Error .

Thanks for all the work on this project.