### PR TITLE
Add edition to front matter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ html: $(addprefix build/,$(SOURCES:.md=.html))
 docx: $(addprefix build/,$(SOURCES:.md=.docx))
 pdf: $(addprefix build/,$(SOURCES:.md=.pdf))
 
-build/%.docx: build/%.form build/%.directions build/%.title build/%.blanks build/%.signatures styles.json | build $(DOCX)
-	$(DOCX) --title "$(shell cat build/$*.title)" --number outline --indent-margins --left-align-title --values build/$*.blanks --directions build/$*.directions --styles styles.json --signatures build/$*.signatures $< > $@
+build/%.docx: build/%.form build/%.directions build/%.title build/%.edition build/%.blanks build/%.signatures styles.json | build $(DOCX)
+	$(DOCX) --title "$(shell cat build/$*.title)" --edition "$(shell cat build/$*.edition)" --number outline --indent-margins --left-align-title --values build/$*.blanks --directions build/$*.directions --styles styles.json --signatures build/$*.signatures $< > $@
 
-build/%.md: build/%.form build/%.directions build/%.title build/%.blanks | build $(COMMONMARK)
-	$(COMMONMARK) stringify --title "$(shell cat build/$*.title)" --values build/$*.blanks --directions build/$*.directions --ordered --ids < $< > $@
+build/%.md: build/%.form build/%.directions build/%.title build/%.edition build/%.blanks | build $(COMMONMARK)
+	$(COMMONMARK) stringify --title "$(shell cat build/$*.title)" --edition "$(shell cat build/$*.edition)" --values build/$*.blanks --directions build/$*.directions --ordered --ids < $< > $@
 
-build/%.html: build/%.form build/%.directions build/%.title build/%.blanks | build $(COMMONMARK)
-	$(HTML) stringify --title "$(shell cat build/$*.title)" --values build/$*.blanks --directions build/$*.directions --html5 --lists < $< > $@
+build/%.html: build/%.form build/%.directions build/%.title build/%.edition build/%.blanks | build $(COMMONMARK)
+	$(HTML) stringify --title "$(shell cat build/$*.title)" --edition "$(shell cat build/$*.edition)" --values build/$*.blanks --directions build/$*.directions --html5 --lists < $< > $@
 
 %.pdf: %.docx
 	unoconv $<
@@ -39,6 +39,9 @@ build/%.form: build/%.parsed | build $(JSON)
 
 build/%.title: build/%.parsed | build $(JSON)
 	$(JSON) frontMatter.title < $< > $@
+
+build/%.edition: build/%.parsed | build $(JSON)
+	$(JSON) frontMatter.edition < $< > $@
 
 build/%.directions: build/%.parsed | build $(JSON)
 	$(JSON) directions < $< > $@

--- a/nda.md
+++ b/nda.md
@@ -1,5 +1,6 @@
 ---
 title: Nondisclosure Agreement
+edition: Working Draft
 blanks:
   Expiration Anniversary: first
 signatures:


### PR DESCRIPTION
@kennyr87 you might find this handy, as well.

For forms I manage, I typically `git checkout -b release`, edit the front matter to set the edition. `git commit -m "Version $version" ; git tag "v$version" ; git push origin "v$version"` and drop the `release` branch.

In the past I've configured `make` to read the edition from a Git tag, but that's usually bit me in the end. It's slightly annoying not to have the tagged release commits on `master`/`main`. But so far, it's been worth it.